### PR TITLE
[BUGFIX] Correct Typo in Layout path declaration

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -8,7 +8,7 @@ plugin.tx_t3oodle {
             0 = EXT:t3oodle/Resources/Private/Partials/
             1 = {$plugin.tx_t3oodle_main.view.partialRootPath}
         }
-        layputRootPaths {
+        layoutRootPaths {
             0 = EXT:tx_t3oodle/Resources/Private/Layouts/
             1 = {$plugin.tx_t3oodle_main.view.layoutRootPath}
         }


### PR DESCRIPTION
During the update to v11 the TypoScript was refactored. Unfortunately, a typo appeared inside the TypoScript for layout registering. Fix this typo to ensure the constant setting is used for adding own Fluid Layout paths.