### PR TITLE
[TASK] FS-1400: Deprecate `UserIdentUtility` in favour of `UserIdentService`

### DIFF
--- a/Classes/Controller/PollController.php
+++ b/Classes/Controller/PollController.php
@@ -75,6 +75,7 @@ use FGTCLB\T3oodle\Exception\Permission\SuggestNewOptionsDeniedEception;
 use FGTCLB\T3oodle\Exception\Permission\UpdateSuggestionDeniedException;
 use FGTCLB\T3oodle\Exception\Permission\VoteResetNotAllowedException;
 use FGTCLB\T3oodle\Exception\Permission\VotingDeniedException;
+use FGTCLB\T3oodle\Service\UserIdentService;
 use FGTCLB\T3oodle\Traits\ControllerValidatorManipulatorTrait;
 use FGTCLB\T3oodle\Utility\CookieUtility;
 use FGTCLB\T3oodle\Utility\DateTimeUtility;
@@ -114,17 +115,15 @@ final class PollController extends ActionController
      */
     protected string $currentUserIdent = '';
     protected PollPermission $pollPermission;
-    protected PollFrontendUserRepository $userRepository;
-    protected PersistenceManagerInterface $persistenceManager;
+
     public function __construct(
-        PersistenceManagerInterface $persistenceManager,
-        protected PollRepository $pollRepository,
-        protected OptionRepository $optionRepository,
-        protected VoteRepository $voteRepository,
-        PollFrontendUserRepository $userRepository
+        private PersistenceManagerInterface $persistenceManager,
+        private PollRepository $pollRepository,
+        private OptionRepository $optionRepository,
+        private VoteRepository $voteRepository,
+        private PollFrontendUserRepository $userRepository,
+        private UserIdentService $userIdentService,
     ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->userRepository = $userRepository;
     }
 
     public function initializeAction(): void
@@ -279,7 +278,7 @@ final class PollController extends ActionController
 
         if (!$this->currentUser) {
             if ($this->currentUserIdent === '' || $this->currentUserIdent === '0') {
-                $this->currentUserIdent = UserIdentUtility::generateNewUserIdent();
+                $this->currentUserIdent = $this->userIdentService->generateNewUserIdent();
             }
             $vote->setParticipantIdent($this->currentUserIdent);
             CookieUtility::set('userIdent', $this->currentUserIdent);
@@ -636,7 +635,7 @@ final class PollController extends ActionController
 
         if (!$this->currentUser) {
             if ($this->currentUserIdent === '' || $this->currentUserIdent === '0') {
-                $this->currentUserIdent = base64_encode(uniqid('', true) . uniqid('', true));
+                $this->currentUserIdent = $this->userIdentService->generateNewUserIdent();
             }
             CookieUtility::set('userIdent', $this->currentUserIdent);
         }
@@ -828,7 +827,7 @@ final class PollController extends ActionController
 
         if (!$this->currentUser) {
             if ($this->currentUserIdent === '' || $this->currentUserIdent === '0') {
-                $this->currentUserIdent = base64_encode(uniqid('', true) . uniqid('', true));
+                $this->currentUserIdent = $this->userIdentService->generateNewUserIdent();
                 $this->settings['_currentUserIdent'] = $this->currentUserIdent;
                 $this->pollPermission = GeneralUtility::makeInstance(
                     PollPermission::class,
@@ -1053,11 +1052,10 @@ final class PollController extends ActionController
 
     private function initializeCurrentUserOrUserIdent(): void
     {
-        $this->currentUserIdent = UserIdentUtility::getCurrentUserIdent() ?? '';
+        $this->currentUserIdent = $this->userIdentService->getCurrentUserIdent() ?? '';
         if (MathUtility::canBeInterpretedAsInteger($this->currentUserIdent)) {
             $this->currentUser = $this->userRepository->findByUid((int)$this->currentUserIdent);
         }
-
         $this->settings['_currentUser'] = $this->currentUser;
         $this->settings['_currentUserIdent'] = $this->currentUserIdent;
     }

--- a/Classes/Domain/Model/BasePoll.php
+++ b/Classes/Domain/Model/BasePoll.php
@@ -13,6 +13,7 @@ use FGTCLB\T3oodle\Domain\Enumeration\PollStatus;
 use FGTCLB\T3oodle\Domain\Enumeration\Visibility;
 use FGTCLB\T3oodle\Domain\Model\PollFrontendUser as FrontendUser;
 use FGTCLB\T3oodle\Domain\Permission\PollPermission;
+use FGTCLB\T3oodle\Service\UserIdentService;
 use FGTCLB\T3oodle\Traits\Model\DynamicUserProperties;
 use FGTCLB\T3oodle\Traits\Model\RecordDatePropertiesTrait;
 use FGTCLB\T3oodle\Utility\DateTimeUtility;
@@ -513,14 +514,14 @@ abstract class BasePoll extends AbstractEntity
 
     public function getIsCurrentUserAuthor(): bool
     {
-        return $this->getAuthorIdent() === UserIdentUtility::getCurrentUserIdent();
+        return $this->getAuthorIdent() === GeneralUtility::makeInstance(UserIdentService::class)->getCurrentUserIdent();
     }
 
     public function getHasCurrentUserVoted(): bool
     {
         /** @var Vote $vote */
         foreach ($this->getVotes() as $vote) {
-            if ($vote->getParticipantIdent() === UserIdentUtility::getCurrentUserIdent()) {
+            if ($vote->getParticipantIdent() === GeneralUtility::makeInstance(UserIdentService::class)->getCurrentUserIdent()) {
                 return true;
             }
         }

--- a/Classes/Domain/Permission/PollPermission.php
+++ b/Classes/Domain/Permission/PollPermission.php
@@ -14,6 +14,7 @@ use FGTCLB\T3oodle\Domain\Enumeration\PollStatus;
 use FGTCLB\T3oodle\Domain\Enumeration\Visibility;
 use FGTCLB\T3oodle\Domain\Model\BasePoll;
 use FGTCLB\T3oodle\Domain\Model\Vote;
+use FGTCLB\T3oodle\Service\UserIdentService;
 use FGTCLB\T3oodle\Service\UserService;
 use FGTCLB\T3oodle\Utility\TranslateUtility;
 use FGTCLB\T3oodle\Utility\UserIdentUtility;
@@ -33,7 +34,7 @@ class PollPermission
         string $currentUserIdent = null,
         private readonly array $controllerSettings = [],
     ) {
-        $this->currentUserIdent = $currentUserIdent ?? UserIdentUtility::getCurrentUserIdent();
+        $this->currentUserIdent = $currentUserIdent ?? GeneralUtility::makeInstance(UserIdentService::class)->getCurrentUserIdent();
         $this->userService = GeneralUtility::makeInstance(UserService::class);
     }
 

--- a/Classes/Domain/Repository/PollRepository.php
+++ b/Classes/Domain/Repository/PollRepository.php
@@ -14,11 +14,13 @@ use Doctrine\DBAL\Exception;
 use FGTCLB\T3oodle\Domain\Enumeration\Visibility;
 use FGTCLB\T3oodle\Domain\Model\BasePoll;
 use FGTCLB\T3oodle\Event\PollRepository\FindPollsEvent;
+use FGTCLB\T3oodle\Service\UserIdentService;
 use FGTCLB\T3oodle\Service\UserService;
 use FGTCLB\T3oodle\Utility\UserIdentUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
@@ -91,7 +93,7 @@ final class PollRepository extends Repository
                         $query->equals('visibility', Visibility::LISTED),
                         $query->equals('isPublished', true),
                     ),
-                    $query->equals('authorIdent', UserIdentUtility::getCurrentUserIdent()),
+                    $query->equals('authorIdent', GeneralUtility::makeInstance(UserIdentService::class)->getCurrentUserIdent()),
                 );
             }
         } else {

--- a/Classes/Service/UserIdentService.php
+++ b/Classes/Service/UserIdentService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\T3oodle\Service;
+
+use FGTCLB\T3oodle\Utility\CookieUtility;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Service around retrieving current user ident.
+ */
+#[Autoconfigure(public: true)]
+final class UserIdentService
+{
+    private const CURRENT_USER_IDENT_IDENTIFIER = 't3oodle-current-user-ident';
+
+    public function __construct(
+        #[Autowire(service: 'cache.runtime')]
+        private readonly FrontendInterface $runtimeCache,
+    ) {
+    }
+
+    public function getCurrentUserIdent(?Context $context = null): ?string
+    {
+        $currentUserIdent = $this->runtimeCache->get(self::CURRENT_USER_IDENT_IDENTIFIER);
+        if ($currentUserIdent !== null) {
+            return $currentUserIdent;
+        }
+        $userAspect = $this->getCurrentUserAspect($context);
+        $currentUserIdent = $userAspect->isLoggedIn()
+            ? (string)$userAspect->get('id')
+            : CookieUtility::get('userIdent');
+        if ($currentUserIdent !== null) {
+            $this->runtimeCache->set(self::CURRENT_USER_IDENT_IDENTIFIER, $currentUserIdent);
+        }
+        return $currentUserIdent;
+    }
+
+    public function getCurrentUserAspect(?Context $context = null): UserAspect
+    {
+        $context ??= GeneralUtility::makeInstance(Context::class);
+        /** @var UserAspect $userAspect */
+        $userAspect = $context->getAspect('frontend.user');
+        return $userAspect;
+    }
+
+    public function generateNewUserIdent(): string
+    {
+        return base64_encode(uniqid('', true) . uniqid('', true));
+    }
+}

--- a/Classes/Service/UserService.php
+++ b/Classes/Service/UserService.php
@@ -5,18 +5,24 @@ declare(strict_types=1);
 namespace FGTCLB\T3oodle\Service;
 
 use FGTCLB\T3oodle\Utility\SettingsUtility;
-use FGTCLB\T3oodle\Utility\UserIdentUtility;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException;
 
+#[Autoconfigure(public: true)]
 final class UserService
 {
+    public function __construct(
+        private UserIdentService $userIdentService,
+    ) {
+    }
+
     /**
      * @throws InvalidConfigurationTypeException
      */
     public function userIsAdmin(): bool
     {
-        $currentUserIdent = UserIdentUtility::getCurrentUserIdent();
+        $currentUserIdent = $this->userIdentService->getCurrentUserIdent();
         if (!is_numeric($currentUserIdent)) {
             return false;
         }
@@ -51,7 +57,7 @@ final class UserService
         }
 
         $adminUserGroupUids = GeneralUtility::intExplode(',', $settings['adminUserGroupUids'], true);
-        $userAspect = UserIdentUtility::getCurrentUserAspect();
+        $userAspect = $this->userIdentService->getCurrentUserAspect();
         $setAdminGroups = array_intersect($userAspect->getGroupIds(), $adminUserGroupUids);
 
         return count($setAdminGroups) > 0;

--- a/Classes/Utility/UserIdentUtility.php
+++ b/Classes/Utility/UserIdentUtility.php
@@ -9,44 +9,54 @@ namespace FGTCLB\T3oodle\Utility;
  *  |
  *  | (c) 2020-2021 Armin Vieweg <info@v.ieweg.de>
  */
-use TYPO3\CMS\Core\Context\Context;
+
+use FGTCLB\T3oodle\Service\UserIdentService;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * @deprecated will be removed in next major version. Use {@see UserIdentService} instead.
+ */
 final class UserIdentUtility
 {
-    /**
-     * @var string|null
-     */
-    private static ?string $currentUserIdent = null;
-
     public static function getCurrentUserIdent(): ?string
     {
-        if (self::$currentUserIdent !== null) {
-            return self::$currentUserIdent;
-        }
-
-        $userAspect = self::getCurrentUserAspect();
-        if ($userAspect->isLoggedIn()) {
-            self::$currentUserIdent = (string)$userAspect->get('id');
-        } else {
-            self::$currentUserIdent = CookieUtility::get('userIdent') ?? '';
-        }
-
-        return self::$currentUserIdent;
+        trigger_error(
+            sprintf(
+                __METHOD__ . ' is deprecated, use "%s::%s" instead',
+                UserIdentService::class, 'getCurrentUserIdent'
+            ),
+            E_USER_DEPRECATED,
+        );
+        return self::getUserIdentService()->getCurrentUserIdent();
     }
 
     public static function generateNewUserIdent(): string
     {
-        return base64_encode(uniqid('', true) . uniqid('', true));
+        trigger_error(
+            sprintf(
+                __METHOD__ . ' is deprecated, use "%s::%s" instead',
+                UserIdentService::class, 'generateNewUserIdent'
+            ),
+            E_USER_DEPRECATED,
+        );
+        return self::getUserIdentService()->generateNewUserIdent();
     }
 
     public static function getCurrentUserAspect(): UserAspect
     {
-        $context = GeneralUtility::makeInstance(Context::class);
-        /** @var UserAspect $userAspect */
-        $userAspect = $context->getAspect('frontend.user');
+        trigger_error(
+            sprintf(
+                __METHOD__ . ' is deprecated, use "%s::%s" instead',
+                UserIdentService::class, 'getCurrentUserAspect'
+            ),
+            E_USER_DEPRECATED,
+        );
+        return self::getUserIdentService()->getCurrentUserAspect();
+    }
 
-        return $userAspect;
+    private static function getUserIdentService(): UserIdentService
+    {
+        return GeneralUtility::makeInstance(UserIdentService::class);
     }
 }

--- a/Classes/ViewHelpers/PermissionViewHelper.php
+++ b/Classes/ViewHelpers/PermissionViewHelper.php
@@ -13,6 +13,7 @@ namespace FGTCLB\T3oodle\ViewHelpers;
 use FGTCLB\T3oodle\Domain\Model\BasePoll;
 use FGTCLB\T3oodle\Domain\Permission\AccessDeniedException;
 use FGTCLB\T3oodle\Domain\Permission\PollPermission;
+use FGTCLB\T3oodle\Service\UserIdentService;
 use FGTCLB\T3oodle\Utility\UserIdentUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -57,7 +58,7 @@ final class PermissionViewHelper extends AbstractConditionViewHelper
     public static function verdict(array $arguments, RenderingContextInterface $renderingContext): bool
     {
         $permissionClass = $arguments['permissionClassName'];
-        $currentUserIdent = UserIdentUtility::getCurrentUserIdent();
+        $currentUserIdent = GeneralUtility::makeInstance(UserIdentService::class)->getCurrentUserIdent();
         $settings = $renderingContext->getVariableProvider()->get('settings');
         $poll = $arguments['poll'];
         /** @var PollPermission $permission */


### PR DESCRIPTION
Static cache propertiers are bad design and leads to a lot of
headache and hard to nail down issues during test executions.

This change introduces the new non-static `UserIdentSerice`
using the TYPO3 `cache.runtime` cache for internal caching
and is used in the now deprecated `UserIdentUtility` for the
public facing methods.

Usages are adopted right away within the extension.
