### PR TITLE
[TASK] FS-1407: Remove `final` from `PollRepository`

### DIFF
--- a/Classes/Domain/Repository/PollRepository.php
+++ b/Classes/Domain/Repository/PollRepository.php
@@ -26,8 +26,10 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<BasePoll>
+ * **Be aware** that this class cannot be made final because it is currently extended in projects.
+ * @todo Make this class final in `3.0.0` after introducing proper "model class" replacement ability.
  */
-final class PollRepository extends Repository
+class PollRepository extends Repository
 {
     protected EventDispatcherInterface $eventDispatcher;
     private UserService $userService;


### PR DESCRIPTION
`PollRepository` is extendend in project to use other
extbase models. This needs another approach to allow
that with a proper API and deprecation phase.

Remove the `final` as short solution and prepare the
class properly and make it final in the next major
version.
