### PR TITLE
[TASK] FS-1414: Use `cgl` in checkmode in GitHub actions

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -25,7 +25,7 @@ jobs:
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure UTF-8 files do not contain BOM"
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkBom"

--- a/Classes/Controller/PollController.php
+++ b/Classes/Controller/PollController.php
@@ -96,8 +96,8 @@ use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
-use TYPO3\CMS\Extbase\Property\TypeConverter\ObjectConverter;
 use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
+use TYPO3\CMS\Extbase\Property\TypeConverter\ObjectConverter;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 final class PollController extends ActionController


### PR DESCRIPTION
This change uses `cgl checkmode` now with the added `-n` option
when executing cgl tests using `runTests.sh` during GitHub CI/CD.

To make it green cgl fixes are applied in the same step.

Used command(s):

```bash
Build/Scripts/runTests.sh -s cgl
```

> [!NOTE]
> See https://github.com/fgtclb/t3oodle/actions/runs/27608895843/job/81627895478?pr=23
> failed as expected before applying the cgl fixes.
