### PR TITLE
[BUGFIX] FS-1606: Select mail field for user property lookup

### DIFF
--- a/Classes/Traits/Model/DynamicUserProperties.php
+++ b/Classes/Traits/Model/DynamicUserProperties.php
@@ -78,11 +78,17 @@ trait DynamicUserProperties
             return self::$userRowCache[$uid];
         }
 
+        $selectFields = array_values(array_unique(array_filter([
+            'uid',
+            self::$typoscriptSettings['frontendUserNameField'] ?? null,
+            self::$typoscriptSettings['frontendUserMailField'] ?? null,
+        ])));
+
         $pool = GeneralUtility::makeInstance(ConnectionPool::class);
         $connection = $pool->getConnectionForTable('fe_users');
         $queryBuilder = $connection->createQueryBuilder();
         $result = $queryBuilder
-            ->select('uid', self::$typoscriptSettings['frontendUserNameField'])
+            ->select(...$selectFields)
             ->from('fe_users')
             ->where($queryBuilder->expr()->eq(
                 'uid',


### PR DESCRIPTION
## What & why

`DynamicUserProperties::getUserRow()` selected only the configured
`frontendUserNameField`, but `getPropertyDynamically()` reads the
`frontendUserMailField` (`email`) from that same cached row when resolving a
user's mail address.

When the frontend-user model has no matching getter — e.g. `PollFrontendUser`
has no `getEmail()` — the lookup falls through to the database row, where the
mail column was never part of the `SELECT` and is therefore always `null`.
Resolving a creator's mail (for instance when adding a suggestion in suggest
mode) then fails with:

```
#1776774128 InvalidArgumentException: Field "email" not given.
```

## Fix

Select the configured name **and** mail fields (deduplicated) so the cached
`fe_users` row carries both values.

Refs: FS-1606