### PR TITLE
[BUGFIX] FS-1606: Map poll subtype when updating a poll

### DIFF
--- a/Classes/Controller/PollController.php
+++ b/Classes/Controller/PollController.php
@@ -933,6 +933,26 @@ final class PollController extends ActionController
         return $this->htmlResponse();
     }
 
+    public function initializeUpdateAction(): void
+    {
+        if ($this->request->hasArgument('poll') && is_array($this->request->getArgument('poll'))) {
+            $poll = $this->request->getArgument('poll');
+            $pollType = $poll['type'] ?? null;
+            if (is_string($pollType) && $pollType !== BasePoll::class && is_a($pollType, BasePoll::class, true)) {
+                // Map the submitted data onto the concrete subtype instead of the abstract BasePoll root
+                // argument, so subclass-only properties can be updated as well (mirrors createAction).
+                $poll['__type'] = $pollType;
+                $this->request = $this->request->withArgument('poll', $poll);
+                $this->arguments->getArgument('poll')->getPropertyMappingConfiguration()
+                    ->setTypeConverterOption(
+                        ObjectConverter::class,
+                        (string)ObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED,
+                        true
+                    );
+            }
+        }
+    }
+
     /**
      * @throws EditPollDeniedException
      * @todo Ensure proper return type is set


### PR DESCRIPTION
## What & why

`initializeCreateAction()` forwards the submitted poll `type` as the Extbase
`__type` override (and enables `CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED`), so
the abstract `BasePoll` root argument is mapped onto the concrete poll subtype.

`updateAction()` had no corresponding `initializeUpdateAction()`, so on update
the submitted data was mapped against `BasePoll` — which does not declare
subclass-only properties. Saving an edited poll whose subtype adds its own
properties then fails, for example (subclass property from a downstream
project):

```
Property "limitVotingToGroup" was not found in target object of
type "FGTCLB\T3oodle\Domain\Model\BasePoll".
```

## Fix

Add `initializeUpdateAction()` mirroring the create path, so the concrete
subtype is used for property mapping on update as well. With `__identity` +
`__type` present, Extbase fetches the existing concrete instance and maps the
remaining properties against its schema.

Refs: FS-1606