### PR TITLE
[BUGFIX] FS-1606: Redirect finished poll on repeated finish

### DIFF
--- a/Classes/Controller/PollController.php
+++ b/Classes/Controller/PollController.php
@@ -393,6 +393,14 @@ final class PollController extends ActionController
         $finishPollAllowedEvent = new FinishPollAllowedEvent($poll, $finishPollAllowed, $this);
         $this->eventDispatcher->dispatch($finishPollAllowedEvent);
         if (!$finishPollAllowedEvent->isAllowed()) {
+            if ($poll->isFinished()) {
+                // Poll has already been finished (e.g. browser back after finalizing): redirect to the
+                // poll instead of throwing a hard error for this idempotent re-request.
+                return new RedirectResponse(
+                    $this->uriBuilder
+                        ->uriFor('show', ['poll' => $poll])
+                );
+            }
             throw new FinishPollDeniedException(
                 'Finish poll is not allowed!',
                 1753714157


### PR DESCRIPTION
## What & why

`finishAction()` throws `FinishPollDeniedException` when finishing is not
allowed. Once a poll is finished, `isFinishAllowed()` returns `false` (it
requires `!$poll->isFinished()`), so navigating back to the finish URL — e.g.
browser back after finalizing — re-triggers the action and produces a hard
error page:

```
#1753714157 FinishPollDeniedException: Finish poll is not allowed!
```

## Fix

When finishing is denied **solely because the poll is already finished**,
redirect to the poll (the `show` action) instead of throwing, making the
re-request idempotent. Genuine permission denials on unfinished polls still
raise the exception.

Refs: FS-1606