### PR TITLE
[BUGFIX] FS-1611: Return cached user ident only when it is a string

### DIFF
--- a/Classes/Service/UserIdentService.php
+++ b/Classes/Service/UserIdentService.php
@@ -28,7 +28,7 @@ final class UserIdentService
     public function getCurrentUserIdent(?Context $context = null): ?string
     {
         $currentUserIdent = $this->runtimeCache->get(self::CURRENT_USER_IDENT_IDENTIFIER);
-        if ($currentUserIdent !== null) {
+        if (is_string($currentUserIdent)) {
             return $currentUserIdent;
         }
         $userAspect = $this->getCurrentUserAspect($context);


### PR DESCRIPTION
## What & why

`UserIdentService::getCurrentUserIdent()` reads the current user ident from the `cache.runtime` cache and returns it early when a value is present. TYPO3 cache frontends return boolean `false` on a **cache miss**, not `null`, but the early-return guard only checked against `null`:

```php
$currentUserIdent = $this->runtimeCache->get(self::CURRENT_USER_IDENT_IDENTIFIER);
if ($currentUserIdent !== null) {
    return $currentUserIdent; // <- false is returned verbatim
}
```

On a cold runtime cache the method therefore returned `false` through its `?string` return type and crashed with:

```
TypeError: FGTCLB\T3oodle\Service\UserIdentService::getCurrentUserIdent():
Return value must be of type ?string, false returned
```

Because `PollController::initializeCurrentUserOrUserIdent()` calls this during `initializeAction()`, **every poll action** failed whenever the runtime cache was cold.

## Fix

Guard the early return with `is_string()` so a cache miss (`false`) falls through to the regular user-aspect / cookie resolution instead of being returned verbatim.

## Regression

Introduced by FS-1400 (`f0324415`, "Deprecate `UserIdentUtility` in favour of `UserIdentService`").